### PR TITLE
feat: Adds support for Quarto Shiny files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "faucet-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faucet-server"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Andrés F. Quintero <afquinteromoreano@gmail.com>"]
 description = "Welcome to Faucet, your go-to solution for deploying Plumber APIs and Shiny Applications with blazing speed and efficiency. Faucet is a high-performance server built with Rust, offering Round Robin and Round Robin + IP Hash load balancing for seamless scaling and distribution of your R applications. Whether you're a data scientist, developer, or DevOps enthusiast, Faucet streamlines the deployment process, making it easier than ever to manage replicas and balance loads effectively."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,7 @@ fn is_shiny(dir: &Path) -> bool {
 enum ServerType {
     Plumber,
     Shiny,
+    QuartoShiny,
     Auto,
 }
 
@@ -74,9 +75,17 @@ pub struct StartArgs {
     #[arg(long, short, env = "FAUCET_RSCRIPT", default_value = "Rscript")]
     rscript: OsString,
 
+    /// Command, path, or executable to run quarto.
+    #[arg(long, short, env = "FAUCET_QUARTO", default_value = "quarto")]
+    quarto: OsString,
+
     /// Argument passed on to `appDir` when running Shiny.
     #[arg(long, short, env = "FAUCET_APP_DIR", default_value = None)]
     app_dir: Option<String>,
+
+    /// Quarto Shiny file path.
+    #[arg(long, short, env = "FAUCET_QMD", default_value = None)]
+    qmd: Option<PathBuf>,
 }
 
 #[derive(Parser, Debug)]
@@ -93,6 +102,10 @@ pub struct RouterArgs {
     /// Command, path, or executable to run Rscript.
     #[arg(long, short, env = "FAUCET_RSCRIPT", default_value = "Rscript")]
     rscript: OsString,
+
+    /// Command, path, or executable to run quarto.
+    #[arg(long, short, env = "FAUCET_QUARTO", default_value = "quarto")]
+    quarto: OsString,
 
     /// Router config file.
     #[arg(
@@ -145,6 +158,7 @@ impl StartArgs {
         match self.type_ {
             ServerType::Plumber => WorkerType::Plumber,
             ServerType::Shiny => WorkerType::Shiny,
+            ServerType::QuartoShiny => WorkerType::QuartoShiny,
             ServerType::Auto => {
                 if is_plumber(&self.dir) {
                     WorkerType::Plumber
@@ -173,6 +187,12 @@ impl StartArgs {
     pub fn rscript(&self) -> &OsStr {
         &self.rscript
     }
+    pub fn quarto(&self) -> &OsStr {
+        &self.quarto
+    }
+    pub fn qmd(&self) -> Option<&Path> {
+        self.qmd.as_deref()
+    }
     pub fn app_dir(&self) -> Option<&str> {
         self.app_dir.as_deref()
     }
@@ -194,5 +214,8 @@ impl RouterArgs {
     }
     pub fn rscript(&self) -> &OsStr {
         self.rscript.as_os_str()
+    }
+    pub fn quarto(&self) -> &OsStr {
+        &self.quarto
     }
 }

--- a/src/client/load_balancing/ip_hash.rs
+++ b/src/client/load_balancing/ip_hash.rs
@@ -1,5 +1,6 @@
 use super::LoadBalancingStrategy;
 use super::WorkerConfig;
+use crate::leak;
 use crate::{client::Client, error::FaucetResult};
 use async_trait::async_trait;
 use std::collections::hash_map::DefaultHasher;
@@ -18,7 +19,7 @@ impl Targets {
             let client = Client::builder(*state).build()?;
             targets.push(client);
         }
-        let targets = Box::leak(targets.into_boxed_slice());
+        let targets = leak!(targets);
         Ok(Targets { targets })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,15 @@ pub mod error;
 pub mod http;
 pub(crate) mod networking;
 pub mod server;
+
+#[macro_use]
+macro_rules! leak {
+    ($val:expr, $ty:ty) => {
+        std::boxed::Box::leak(std::boxed::Box::from($val)) as &'static $ty
+    };
+    ($val:expr) => {
+        std::boxed::Box::leak(std::boxed::Box::from($val))
+    };
+}
+
+pub(crate) use leak;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ pub async fn main() -> FaucetResult<()> {
                 .workdir(start_args.dir())
                 .rscript(start_args.rscript())
                 .app_dir(start_args.app_dir())
+                .quarto(start_args.quarto())
+                .qmd(start_args.qmd())
                 .build()?
                 .run()
                 .await?;
@@ -37,6 +39,7 @@ pub async fn main() -> FaucetResult<()> {
             config
                 .run(
                     router_args.rscript(),
+                    router_args.quarto(),
                     router_args.ip_extractor(),
                     router_args.host().parse()?,
                 )


### PR DESCRIPTION
Closes #76

Example on how to use with router is here: https://github.com/ixpantia/faucet-router-example

CLI example:

```
~/p/e/qmd (main|✔) [2]$ faucet start --type quarto-shiny
[2024-07-04T04:36:08Z INFO  faucet] Building the faucet server...
[2024-07-04T04:36:08Z INFO  faucet] Using load balancing strategy: Some(RoundRobin)
[2024-07-04T04:36:08Z INFO  faucet] Will spawn 16 workers
[2024-07-04T04:36:08Z INFO  faucet] Using worker type: QuartoShiny
[2024-07-04T04:36:08Z INFO  faucet] Using IP extractor: ClientAddr
[2024-07-04T04:36:08Z INFO  faucet] Will bind to: 127.0.0.1:3838
[2024-07-04T04:36:08Z INFO  faucet] Using workdir: "."
[2024-07-04T04:36:08Z INFO  faucet] Using Rscript command: "Rscript"
[2024-07-04T04:36:08Z INFO  faucet] Using quarto command: "quarto"
[2024-07-04T04:36:08Z INFO  faucet] Round robin load balancing strategy specified for shiny, switching to IP hash.
[2024-07-04T04:36:08Z ERROR faucet] Failed to invoke R for Worker::1: Missing argument: qmd
[2024-07-04T04:36:08Z ERROR faucet] Exiting...
[2024-07-04T04:36:08Z ERROR faucet] Failed to invoke R for Worker::3: Missing argument: qmd
[2024-07-04T04:36:08Z ERROR faucet] Exiting...
[2024-07-04T04:36:08Z ERROR faucet] Failed to invoke R for Worker::2: Missing argument: qmd
~/p/e/qmd (main|✔) [1]$
```

If we don't specify the `qmd` argument then we get a very clear error message.

Once we include the path in the `qmd` argument it works!

```
~/p/e/qmd (main|✔) $ faucet start --type quarto-shiny --qmd old_faithful.qmd -w 1
[2024-07-04T04:37:21Z INFO  faucet] Building the faucet server...
[2024-07-04T04:37:21Z INFO  faucet] Using load balancing strategy: Some(RoundRobin)
[2024-07-04T04:37:21Z INFO  faucet] Will spawn 1 workers
[2024-07-04T04:37:21Z INFO  faucet] Using worker type: QuartoShiny
[2024-07-04T04:37:21Z INFO  faucet] Using IP extractor: ClientAddr
[2024-07-04T04:37:21Z INFO  faucet] Will bind to: 127.0.0.1:3838
[2024-07-04T04:37:21Z INFO  faucet] Using workdir: "."
[2024-07-04T04:37:21Z INFO  faucet] Using Rscript command: "Rscript"
[2024-07-04T04:37:21Z INFO  faucet] Using quarto command: "quarto"
[2024-07-04T04:37:21Z INFO  faucet] Round robin load balancing strategy specified for shiny, switching to IP hash.
[2024-07-04T04:37:21Z INFO  faucet] Listening on http://127.0.0.1:3838
[2024-07-04T04:37:21Z INFO  faucet] Starting process 1529415 for Worker::1 on port 44641
[2024-07-04T04:37:22Z WARN  Worker::1] Loading required namespace: shiny
[2024-07-04T04:37:22Z WARN  Worker::1]
[2024-07-04T04:37:22Z WARN  Worker::1]
[2024-07-04T04:37:22Z WARN  Worker::1] processing file: old_faithful.qmd
[2024-07-04T04:37:22Z WARN  Worker::1] 1/5
[2024-07-04T04:37:22Z WARN  Worker::1] 2/5 [unnamed-chunk-1]
[2024-07-04T04:37:22Z WARN  Worker::1] 3/5
[2024-07-04T04:37:22Z WARN  Worker::1] 4/5 [unnamed-chunk-2]
[2024-07-04T04:37:22Z WARN  Worker::1] 5/5
[2024-07-04T04:37:22Z WARN  Worker::1] output file: old_faithful.knit.md
[2024-07-04T04:37:22Z WARN  Worker::1]
[2024-07-04T04:37:22Z WARN  Worker::1] pandoc
[2024-07-04T04:37:22Z WARN  Worker::1]   to: html
[2024-07-04T04:37:22Z WARN  Worker::1]   output-file: old_faithful.html
[2024-07-04T04:37:22Z WARN  Worker::1]   standalone: true
[2024-07-04T04:37:22Z WARN  Worker::1]   section-divs: true
[2024-07-04T04:37:22Z WARN  Worker::1]   html-math-method: mathjax
[2024-07-04T04:37:22Z WARN  Worker::1]   wrap: none
[2024-07-04T04:37:22Z WARN  Worker::1]   default-image-extension: png
[2024-07-04T04:37:22Z WARN  Worker::1]
[2024-07-04T04:37:22Z WARN  Worker::1] metadata
[2024-07-04T04:37:22Z WARN  Worker::1]   document-css: false
[2024-07-04T04:37:22Z WARN  Worker::1]   link-citations: true
[2024-07-04T04:37:22Z WARN  Worker::1]   date-format: long
[2024-07-04T04:37:22Z WARN  Worker::1]   lang: en
[2024-07-04T04:37:22Z WARN  Worker::1]   title: Old Faithful
[2024-07-04T04:37:22Z WARN  Worker::1]   server:
[2024-07-04T04:37:22Z WARN  Worker::1]     type: shiny
[2024-07-04T04:37:22Z WARN  Worker::1]
[2024-07-04T04:37:23Z WARN  Worker::1] Loading required package: shiny
[2024-07-04T04:37:23Z WARN  Worker::1] Browse at http://localhost:44641/
[2024-07-04T04:37:23Z WARN  Worker::1]
[2024-07-04T04:37:23Z WARN  Worker::1]
[2024-07-04T04:37:23Z INFO  faucet] Worker::1 is online and ready to serve connections
```
