### PR TITLE
feat: Allows saving of HTTP events into PostgreSQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tower",
+ "uuid",
 ]
 
 [[package]]
@@ -1124,6 +1125,7 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "uuid",
 ]
 
 [[package]]
@@ -1791,6 +1793,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +91,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +112,33 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
 
 [[package]]
 name = "backtrace"
@@ -109,6 +162,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +224,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
+name = "cc"
+version = "1.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+dependencies = [
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +254,31 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -188,10 +321,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -240,12 +394,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool-postgres"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab8a4ea925ce79678034870834602a2980f4b88c09e97feb266496dbb4493d2"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
 name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -256,7 +447,20 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "env_filter"
@@ -288,13 +492,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "faucet-server"
 version = "1.1.0"
 dependencies = [
  "base64",
+ "bytes",
+ "chrono",
  "clap",
  "ctrlc",
  "deadpool",
+ "deadpool-postgres",
  "env_logger",
  "futures-util",
  "fxhash",
@@ -305,9 +528,12 @@ dependencies = [
  "nix",
  "num_cpus",
  "rand",
+ "rustls",
  "serde",
  "sha1",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
@@ -316,10 +542,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "flagset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -328,6 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -400,8 +639,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -409,6 +650,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -446,6 +693,24 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -540,6 +805,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,16 +844,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -584,10 +927,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -611,6 +970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +985,25 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -671,6 +1055,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,12 +1097,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66ea23a2d0e5734297357705193335e0a957696f34bed2f2faefacb2fec336f"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -778,10 +1232,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "scopeguard"
@@ -830,6 +1351,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +1375,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -864,10 +1408,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -901,6 +1478,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1540,58 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5d3742945bc7d7f210693b0c58ae542c6fd47b17adbbda0885f3dcb34a6bdb"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -1028,7 +1693,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1071,10 +1748,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf-8"
@@ -1108,6 +1812,109 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1201,6 +2008,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +2034,26 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,12 @@ fxhash = "0.2.1"
 toml = "0.8.19"
 nix = "0.29.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }
+tokio-postgres = { version = "0.7.12", features = ["with-chrono-0_4"] }
+deadpool-postgres = { version = "0.14.0", features = ["rt_tokio_1"] }
+bytes = "1.8.0"
+tokio-postgres-rustls = "0.13.0"
+rustls = "0.23.15"
+chrono = "0.4.38"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,13 @@ fxhash = "0.2.1"
 toml = "0.8.19"
 nix = "0.29.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }
-tokio-postgres = { version = "0.7.12", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7.12", features = ["with-chrono-0_4", "with-uuid-1"] }
 deadpool-postgres = { version = "0.14.0", features = ["rt_tokio_1"] }
 bytes = "1.8.0"
 tokio-postgres-rustls = "0.13.0"
 rustls = "0.23.15"
 chrono = "0.4.38"
+uuid = { version = "1.11.0", features = ["v7"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ the following SQL query:
 
 ```sql
 CREATE TABLE faucet_http_events (
+    request_uuid UUID,
     namespace TEXT,
     target TEXT,
     worker_route TEXT,

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ the following SQL query:
 CREATE TABLE faucet_http_events (
     request_uuid UUID,
     namespace TEXT,
+    version TEXT,
     target TEXT,
     worker_route TEXT,
     worker_id INT,
@@ -215,7 +216,7 @@ CREATE TABLE faucet_http_events (
     method TEXT,
     path TEXT,
     query_params TEXT,
-    version TEXT,
+    http_version TEXT,
     status SMALLINT,
     user_agent TEXT,
     elapsed BIGINT,

--- a/README.md
+++ b/README.md
@@ -208,9 +208,12 @@ the following SQL query:
 CREATE TABLE faucet_http_events (
     namespace TEXT,
     target TEXT,
+    worker_route TEXT,
+    worker_id INT,
     ip_addr INET,
     method TEXT,
     path TEXT,
+    query_params TEXT,
     version TEXT,
     status SMALLINT,
     user_agent TEXT,

--- a/README.md
+++ b/README.md
@@ -194,6 +194,56 @@ git clone https://github.com/ixpantia/faucet.git
 cargo install --path .
 ```
 
+## HTTP Telemetry
+
+faucet now offers the option of saving HTTP events to a PostgreSQL database.
+This can be very helpful for tracking latency, total API calls and other
+important information.
+
+In order to use this feature you will need a PostgreSQL database with a table
+called `faucet_http_events`. You can create the table using this table with
+the following SQL query:
+
+```sql
+CREATE TABLE faucet_http_events (
+    namespace TEXT,
+    target TEXT,
+    ip_addr INET,
+    method TEXT,
+    path TEXT,
+    version TEXT,
+    status SMALLINT,
+    user_agent TEXT,
+    elapsed BIGINT,
+    time TIMESTAMPTZ
+);
+```
+
+### Connection Strings
+
+In order to connect to the database you will need to pass the
+`FAUCET_TELEMETRY_POSTGRES_STRING` environment variable or the
+`--pg-con-string` CLI argument.
+
+This should include either a connection string or a URL with the `postgres://`
+protocol.
+
+#### Example connection strings
+
+```sh
+FAUCET_TELEMETRY_POSTGRES_STRING="host=localhost user=postgres connect_timeout=10 keepalives=0"
+FAUCET_TELEMETRY_POSTGRES_STRING="host=/var/lib/postgresql,localhost port=1234 user=postgres password='password with spaces'"
+FAUCET_TELEMETRY_POSTGRES_STRING="postgresql://user@localhost"
+FAUCET_TELEMETRY_POSTGRES_STRING="postgresql://user:password@127.0.0.1/mydb?connect_timeout=10"
+```
+
+### Telemetry Namespaces
+
+It is likely you want to track different services on the same database. You
+can control the column `namespace` using the environment variable
+`FAUCET_TELEMETRY_NAMESPACE` or cli argument `--telemetry-namespace`. By
+default, this value is `"faucet"`.
+
 ## Contributing
 
 If you want to contribute to `faucet` please read the

--- a/examples/shiny/app.R
+++ b/examples/shiny/app.R
@@ -1,0 +1,47 @@
+library(shiny)
+library(bslib)
+
+# Define UI for app that draws a histogram ----
+ui <- page_sidebar(
+  # App title ----
+  title = "Hello Shiny!",
+  # Sidebar panel for inputs ----
+  sidebar = sidebar(
+    # Input: Slider for the number of bins ----
+    sliderInput(
+      inputId = "bins",
+      label = "Number of bins:",
+      min = 1,
+      max = 50,
+      value = 30
+    )
+  ),
+  # Output: Histogram ----
+  plotOutput(outputId = "distPlot")
+)
+
+# Define server logic required to draw a histogram ----
+server <- function(input, output) {
+
+  # Histogram of the Old Faithful Geyser Data ----
+  # with requested number of bins
+  # This expression that generates a histogram is wrapped in a call
+  # to renderPlot to indicate that:
+  #
+  # 1. It is "reactive" and therefore should be automatically
+  #    re-executed when inputs (input$bins) change
+  # 2. Its output type is a plot
+  output$distPlot <- renderPlot({
+
+    x    <- faithful$waiting
+    bins <- seq(min(x), max(x), length.out = input$bins + 1)
+
+    hist(x, breaks = bins, col = "#007bc2", border = "white",
+         xlab = "Waiting time to next eruption (in mins)",
+         main = "Histogram of waiting times")
+
+    })
+
+}
+
+shinyApp(ui, server)

--- a/examples/simple/plumber.R
+++ b/examples/simple/plumber.R
@@ -1,5 +1,11 @@
 # plumber.R
 
+#* @param n Seconds to sleep
+#* @get /sleep
+function(n = 1L) {
+  Sys.sleep(as.numeric(n))
+}
+
 #* Echo the parameter that was sent in
 #* @param msg The message to echo back.
 #* @get /echo

--- a/examples/simple/plumber.R
+++ b/examples/simple/plumber.R
@@ -1,4 +1,27 @@
-#* @get /
-function() {
-  "Hello, world!"
+# plumber.R
+
+#* Echo the parameter that was sent in
+#* @param msg The message to echo back.
+#* @get /echo
+function(msg = "") {
+  list(msg = paste0("The message is: '", msg, "'"))
+}
+
+#* Plot out data from the iris dataset
+#* @param spec If provided, filter the data to only this species (e.g. 'setosa')
+#* @get /plot
+#* @serializer png
+function(spec) {
+  myData <- iris
+  title <- "All Species"
+
+  # Filter if the species was specified
+  if (!missing(spec)) {
+    title <- paste0("Only the '", spec, "' Species")
+    myData <- subset(iris, Species == spec)
+  }
+
+  plot(myData$Sepal.Length, myData$Petal.Length,
+    main = title, xlab = "Sepal Length", ylab = "Petal Length"
+  )
 }

--- a/postgres.sql
+++ b/postgres.sql
@@ -1,6 +1,7 @@
 CREATE TABLE faucet_http_events (
     request_uuid UUID,
     namespace TEXT,
+    version TEXT,
     target TEXT,
     worker_route TEXT,
     worker_id INT,
@@ -8,13 +9,12 @@ CREATE TABLE faucet_http_events (
     method TEXT,
     path TEXT,
     query_params TEXT,
-    version TEXT,
+    http_version TEXT,
     status SMALLINT,
     user_agent TEXT,
     elapsed BIGINT,
-    time TIMESTAMPTZ
+    time TIMESTAMPTZ NOT NULL
 );
 
-CREATE INDEX faucet_http_events_request_uuid_idx 
-ON faucet_http_events USING BTREE (request_uuid);
-
+-- For use in timescale
+-- SELECT create_hypertable('faucet_http_events', by_range('time'));

--- a/postgres.sql
+++ b/postgres.sql
@@ -1,9 +1,12 @@
 CREATE TABLE faucet_http_events (
     namespace TEXT,
     target TEXT,
+    worker_route TEXT,
+    worker_id INT,
     ip_addr INET,
     method TEXT,
     path TEXT,
+    query_params TEXT,
     version TEXT,
     status SMALLINT,
     user_agent TEXT,

--- a/postgres.sql
+++ b/postgres.sql
@@ -1,0 +1,13 @@
+CREATE TABLE faucet_http_events (
+    namespace TEXT,
+    target TEXT,
+    ip_addr INET,
+    method TEXT,
+    path TEXT,
+    version TEXT,
+    status SMALLINT,
+    user_agent TEXT,
+    elapsed BIGINT,
+    time TIMESTAMPTZ
+);
+

--- a/postgres.sql
+++ b/postgres.sql
@@ -1,4 +1,5 @@
 CREATE TABLE faucet_http_events (
+    request_uuid UUID,
     namespace TEXT,
     target TEXT,
     worker_route TEXT,
@@ -13,4 +14,7 @@ CREATE TABLE faucet_http_events (
     elapsed BIGINT,
     time TIMESTAMPTZ
 );
+
+CREATE INDEX faucet_http_events_request_uuid_idx 
+ON faucet_http_events USING BTREE (request_uuid);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -187,6 +187,10 @@ pub struct Args {
     /// Save HTTP events on PostgreSQL under a specific namespace.
     #[arg(long, env = "FAUCET_TELEMETRY_NAMESPACE", default_value = "faucet")]
     pub telemetry_namespace: String,
+
+    /// Represents the source code version of the service to run. This is useful for telemetry.
+    #[arg(long, env = "FAUCET_TELEMETRY_VERSION", default_value = None)]
+    pub telemetry_version: Option<String>,
 }
 
 impl StartArgs {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,6 +179,14 @@ pub struct Args {
     /// The strategy for shutting down faucet
     #[arg(long, env = "FAUCET_SHUTDOWN", default_value = "immediate")]
     pub shutdown: Shutdown,
+
+    /// Connection string to a PostgreSQL database for saving HTTP events.
+    #[arg(long, env = "FAUCET_TELEMETRY_POSTGRES_STRING", default_value = None)]
+    pub pg_con_string: Option<String>,
+
+    /// Save HTTP events on PostgreSQL under a specific namespace.
+    #[arg(long, env = "FAUCET_TELEMETRY_NAMESPACE", default_value = "faucet")]
+    pub telemetry_namespace: String,
 }
 
 impl StartArgs {

--- a/src/client/worker.rs
+++ b/src/client/worker.rs
@@ -3,12 +3,13 @@ use crate::{
     leak,
     networking::get_available_sockets,
     server::FaucetServerConfig,
+    shutdown::ShutdownSignal,
 };
 use std::{
     ffi::OsStr,
     net::SocketAddr,
     path::Path,
-    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
 use tokio::{process::Child, task::JoinHandle};
@@ -77,7 +78,7 @@ impl WorkerConfig {
     fn new(
         worker_id: usize,
         addr: SocketAddr,
-        server_config: FaucetServerConfig,
+        server_config: &FaucetServerConfig,
         target_prefix: &str,
     ) -> Self {
         Self {
@@ -87,6 +88,7 @@ impl WorkerConfig {
             workdir: server_config.workdir,
             target: leak!(format!("{}Worker::{}", target_prefix, worker_id)),
             app_dir: server_config.app_dir,
+
             wtype: server_config.server_type,
             rscript: server_config.rscript,
             quarto: server_config.quarto,
@@ -228,14 +230,9 @@ const RECHECK_INTERVAL: Duration = Duration::from_millis(250);
 
 pub struct WorkerChild {
     handle: Option<JoinHandle<FaucetResult<()>>>,
-    stopper: tokio::sync::mpsc::Sender<()>,
 }
 
 impl WorkerChild {
-    pub async fn kill(&mut self) {
-        let _ = self.stopper.try_send(());
-        self.wait_until_done().await;
-    }
     pub async fn wait_until_done(&mut self) {
         if let Some(handle) = self.handle.take() {
             let _ = handle.await;
@@ -243,18 +240,17 @@ impl WorkerChild {
     }
 }
 
-fn spawn_worker_task(config: WorkerConfig) -> WorkerChild {
-    let (stopper, mut rx) = tokio::sync::mpsc::channel(1);
+fn spawn_worker_task(config: WorkerConfig, shutdown: ShutdownSignal) -> WorkerChild {
     let handle = tokio::spawn(async move {
-        let pid = AtomicU32::new(0);
-        loop {
-            let child_manage_closure = || async {
-                let mut child = config.spawn_process(config);
-                pid.store(
-                    child.id().expect("Failed to get plumber worker PID"),
-                    Ordering::SeqCst,
-                );
-                log::info!(target: "faucet", "Starting process {pid} for {target} on port {port}", port = config.addr.port(), target = config.target, pid = pid.load(Ordering::SeqCst));
+        'outer: loop {
+            let mut child = config.spawn_process(config);
+            let pid = child.id().expect("Failed to get plumber worker PID");
+
+            // We will run this loop asynchrnously on this same thread.
+            // We will use this to wait for either the stop signal
+            // or the child exiting
+            let child_loop = async {
+                log::info!(target: "faucet", "Starting process {pid} for {target} on port {port}", port = config.addr.port(), target = config.target);
                 loop {
                     // Try to connect to the socket
                     let check_status = check_if_online(config.addr).await;
@@ -272,36 +268,36 @@ fn spawn_worker_task(config: WorkerConfig) -> WorkerChild {
 
                     tokio::time::sleep(RECHECK_INTERVAL).await;
                 }
-                child.wait().await
+                FaucetResult::Ok(child.wait().await?)
             };
-
             tokio::select! {
-                status = child_manage_closure() => {
+                // If we receive a stop signal that means we will stop the outer loop
+                // and kill the process
+                _ = shutdown.wait() => {
+                    let _ = child.kill().await;
+                    log::info!(target: "faucet", "{target}'s process ({pid}) killed", target = config.target);
+                    break 'outer;
+                },
+                // If our child loop stops that means the process crashed. We will restart it
+                status = child_loop => {
                     config
                         .is_online
                         .store(false, std::sync::atomic::Ordering::SeqCst);
-                    log::error!(target: "faucet", "{target}'s process ({}) exited with status {}", pid.load(Ordering::SeqCst), status?, target = config.target);
-                },
-                _ = rx.recv() => break,
-            }
-        }
-        match pid.load(Ordering::SeqCst) {
-            0 => (), // If PID is 0 that means the process has not even started
-            pid => {
-                log::info!(target: "faucet", "{target}'s process ({pid}) killed", target = config.target)
+                    log::error!(target: "faucet", "{target}'s process ({}) exited with status {}", pid, status?, target = config.target);
+                    continue 'outer;
+                }
             }
         }
         FaucetResult::Ok(())
     });
     WorkerChild {
         handle: Some(handle),
-        stopper,
     }
 }
 
 impl Worker {
-    pub fn from_config(config: WorkerConfig) -> FaucetResult<Self> {
-        let child = spawn_worker_task(config);
+    pub fn from_config(config: WorkerConfig, shutdown: ShutdownSignal) -> FaucetResult<Self> {
+        let child = spawn_worker_task(config, shutdown);
         Ok(Self { child, config })
     }
 }
@@ -314,14 +310,15 @@ impl Workers {
     pub(crate) async fn new(
         server_config: FaucetServerConfig,
         target_prefix: &str,
+        shutdown: ShutdownSignal,
     ) -> FaucetResult<Self> {
         let workers = get_available_sockets(server_config.n_workers.get())
             .await
             .enumerate()
             .map(|(id, socket_addr)| {
-                WorkerConfig::new(id + 1, socket_addr, server_config, target_prefix)
+                WorkerConfig::new(id + 1, socket_addr, &server_config, target_prefix)
             })
-            .map(Worker::from_config)
+            .map(|config| Worker::from_config(config, shutdown.clone()))
             .collect::<FaucetResult<Box<[Worker]>>>()?;
         Ok(Self { workers })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,14 @@ pub enum FaucetError {
     BufferCapacity(tokio_tungstenite::tungstenite::error::CapacityError),
     ProtocolViolation(tokio_tungstenite::tungstenite::error::ProtocolError),
     WSWriteBufferFull(tokio_tungstenite::tungstenite::Message),
+    PostgreSQL(tokio_postgres::Error),
     AttackAttempt,
+}
+
+impl From<tokio_postgres::Error> for FaucetError {
+    fn from(value: tokio_postgres::Error) -> Self {
+        Self::PostgreSQL(value)
+    }
 }
 
 impl From<tokio_tungstenite::tungstenite::Error> for FaucetError {
@@ -141,6 +148,7 @@ impl std::fmt::Display for FaucetError {
             Self::Utf8Coding => write!(f, "Utf8 Coding error"),
             Self::BufferCapacity(cap_err) => write!(f, "Buffer Capacity: {cap_err}"),
             Self::WSWriteBufferFull(buf) => write!(f, "Web Socket Write buffer full, {buf}"),
+            Self::PostgreSQL(value) => write!(f, "PostgreSQL error: {value}"),
             Self::BadRequest(r) => match r {
                 BadRequestReason::UnsupportedUrlScheme => {
                     write!(f, "UnsupportedUrlScheme use ws:// os wss://")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod global_conn;
 pub(crate) mod networking;
 pub mod server;
 pub mod shutdown;
+pub mod telemetry;
 
 macro_rules! leak {
     ($val:expr, $ty:ty) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,11 @@ pub async fn main() -> FaucetResult<()> {
     };
 
     let telemetry = cli_args.pg_con_string.map(|pg_con| {
-        match TelemetryManager::start(cli_args.telemetry_namespace, pg_con) {
+        match TelemetryManager::start(
+            &cli_args.telemetry_namespace,
+            cli_args.telemetry_version.as_deref(),
+            &pg_con,
+        ) {
             Ok(telemetry) => telemetry,
             Err(e) => {
                 eprintln!("Unable to start telemetry manager: {e}");
@@ -83,7 +87,7 @@ pub async fn main() -> FaucetResult<()> {
     if let Some(telemetry) = telemetry {
         log::debug!("Waiting to stop DB writes");
         drop(telemetry.sender);
-        let _ = telemetry.join_handle.await;
+        let _ = telemetry.http_events_join_handle.await;
     }
 
     Ok(())

--- a/src/server/logging.rs
+++ b/src/server/logging.rs
@@ -72,6 +72,7 @@ pub mod logger {
 
 #[derive(Clone, Copy)]
 pub struct StateData {
+    pub uuid: uuid::Uuid,
     pub ip: IpAddr,
     pub worker_route: Option<&'static str>,
     pub worker_id: usize,
@@ -85,11 +86,13 @@ trait StateLogData: Send + Sync + 'static {
 impl StateLogData for State {
     #[inline(always)]
     fn get_state_data(&self) -> StateData {
+        let uuid = self.uuid;
         let ip = self.remote_addr;
         let worker_id = self.client.config.worker_id;
         let worker_route = self.client.config.worker_route;
         let target = self.client.config.target;
         StateData {
+            uuid,
             ip,
             worker_id,
             worker_route,
@@ -255,6 +258,7 @@ mod tests {
         impl StateLogData for MockState {
             fn get_state_data(&self) -> StateData {
                 StateData {
+                    uuid: uuid::Uuid::now_v7(),
                     ip: IpAddr::V4([127, 0, 0, 1].into()),
                     target: "test",
                     worker_id: 1,
@@ -352,6 +356,7 @@ mod tests {
 
         let log_data = LogData {
             state_data: StateData {
+                uuid: uuid::Uuid::now_v7(),
                 target: "test",
                 ip: IpAddr::V4([127, 0, 0, 1].into()),
                 worker_route: None,

--- a/src/server/logging.rs
+++ b/src/server/logging.rs
@@ -223,7 +223,7 @@ where
 
         log_data.log();
         if let Some(telemetry) = &self.telemetry {
-            telemetry.send(log_data);
+            telemetry.send_http_event(log_data);
         }
 
         Ok(res)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,6 @@
 mod logging;
 pub use logging::{logger, LogData, LogOption};
-mod onion;
+pub mod onion;
 mod router;
 mod service;
 use crate::{

--- a/src/server/onion.rs
+++ b/src/server/onion.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-pub trait Service<Request> {
+pub trait Service<Request>: Send + Sync {
     type Response;
     type Error;
     async fn call(

--- a/src/server/router/mod.rs
+++ b/src/server/router/mod.rs
@@ -132,9 +132,9 @@ impl RouterConfig {
         let mut clients = Vec::with_capacity(self.route.len());
         let mut routes_set = HashSet::with_capacity(self.route.len());
         for route_conf in self.route.into_iter() {
-            let route = route_conf.route.as_str();
-            if !routes_set.insert(route.to_owned()) {
-                return Err(FaucetError::DuplicateRoute(route_conf.route));
+            let route = route_conf.route;
+            if !routes_set.insert(route.clone()) {
+                return Err(FaucetError::DuplicateRoute(route));
             }
             let (client, workers) = FaucetServerBuilder::new()
                 .workdir(route_conf.config.workdir)
@@ -147,10 +147,11 @@ impl RouterConfig {
                 .extractor(ip_from)
                 .app_dir(route_conf.config.app_dir)
                 .telemetry(telemetry)
+                .route(route.clone())
                 .build()?
-                .extract_service(&format!("[{route}]::"), shutdown.clone())
+                .extract_service(shutdown.clone())
                 .await?;
-            routes.push(route_conf.route);
+            routes.push(route);
             all_workers.push(workers);
             clients.push(client);
         }

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -5,20 +5,39 @@ use crate::{
     error::FaucetError,
     server::load_balancing::LoadBalancer,
 };
-use hyper::body::Incoming;
+use hyper::{body::Incoming, header::HeaderValue};
 
 use super::onion::{Layer, Service};
 
 #[derive(Clone)]
 pub(crate) struct State {
+    pub uuid: uuid::Uuid,
     pub remote_addr: IpAddr,
     pub client: Client,
+}
+
+impl State {
+    #[inline(always)]
+    fn new(remote_addr: IpAddr, client: Client) -> State {
+        let uuid = uuid::Uuid::now_v7();
+        State {
+            remote_addr,
+            client,
+            uuid,
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct AddStateService<S> {
     inner: S,
     load_balancer: LoadBalancer,
+}
+
+fn uuid_to_header_value(uuid: uuid::Uuid) -> HeaderValue {
+    let mut buffer = [0u8; uuid::fmt::Hyphenated::LENGTH];
+    HeaderValue::from_str(uuid.hyphenated().encode_lower(&mut buffer))
+        .expect("Unable to convert from uuid to header value, this is a bug")
 }
 
 impl<S, ReqBody> Service<hyper::Request<ReqBody>> for AddStateService<S>
@@ -46,11 +65,17 @@ where
                 return Err(e);
             }
         };
+
         let client = self.load_balancer.get_client(remote_addr).await?;
-        req.extensions_mut().insert(State {
-            remote_addr,
-            client,
-        });
+
+        let state = State::new(remote_addr, client);
+
+        // Add the state's UUID to the request. `X-` headers are depracted
+        // https://www.rfc-editor.org/rfc/rfc6648
+        req.headers_mut()
+            .insert("Faucet-Request-Uuid", uuid_to_header_value(state.uuid));
+
+        req.extensions_mut().insert(state);
         self.inner.call(req, Some(remote_addr)).await
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -57,6 +57,7 @@ impl TelemetryManager {
             let pool = pool.clone();
             tokio::task::spawn(async move {
                 let types = &[
+                    PgType::UUID,        // UUID
                     PgType::TEXT,        // Namespace
                     PgType::TEXT,        // Target
                     PgType::TEXT,        // Worker Route
@@ -106,6 +107,7 @@ impl TelemetryManager {
                             );
 
                             'write: for (timespamp, log_data) in logs_buffer.drain(..) {
+                                let uuid = &log_data.state_data.uuid;
                                 let target = &log_data.state_data.target;
                                 let worker_id = log_data.state_data.worker_id as i32;
                                 let worker_route = log_data.state_data.worker_route;
@@ -133,6 +135,7 @@ impl TelemetryManager {
                                 let copy_result = copy_in_writer
                                     .as_mut()
                                     .write(&[
+                                        uuid,
                                         &namespace,
                                         target,
                                         &worker_route,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,166 @@
+use std::{pin::pin, str::FromStr};
+
+use chrono::Local;
+use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
+use std::io::Write;
+use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
+
+use crate::{
+    error::FaucetResult,
+    server::{LogData, LogOption},
+};
+
+#[derive(Clone)]
+pub struct TelemetrySender {
+    pub sender: UnboundedSender<(chrono::DateTime<Local>, LogData)>,
+}
+
+impl TelemetrySender {
+    pub fn send(&self, data: LogData) {
+        let timestamp = chrono::Local::now();
+        let _ = self.sender.send((timestamp, data));
+    }
+}
+
+pub struct TelemetryManager {
+    _pool: deadpool_postgres::Pool,
+    pub sender: TelemetrySender,
+    pub join_handle: JoinHandle<()>,
+}
+
+fn make_tls() -> tokio_postgres_rustls::MakeRustlsConnect {
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(rustls::RootCertStore::empty())
+        .with_no_client_auth();
+
+    tokio_postgres_rustls::MakeRustlsConnect::new(config)
+}
+
+type PgType = tokio_postgres::types::Type;
+
+impl TelemetryManager {
+    pub fn start(
+        namespace: impl AsRef<str>,
+        database_url: impl AsRef<str>,
+    ) -> FaucetResult<TelemetryManager> {
+        let namespace = Box::<str>::from(namespace.as_ref());
+        let config = tokio_postgres::Config::from_str(database_url.as_ref())?;
+        let mgr_config = ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
+        };
+        let mgr = Manager::from_config(config, make_tls(), mgr_config);
+        let pool = Pool::builder(mgr).max_size(10).build()?;
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(_, LogData)>();
+
+        let join_handle = {
+            let pool = pool.clone();
+            tokio::task::spawn(async move {
+                let types = &[
+                    PgType::TEXT,        // Namespace
+                    PgType::TEXT,        // Target
+                    PgType::INET,        // IpAddr
+                    PgType::TEXT,        // Method
+                    PgType::TEXT,        // Path
+                    PgType::TEXT,        // Version
+                    PgType::INT2,        // Status
+                    PgType::TEXT,        // User Agent
+                    PgType::INT8,        // Elapsed
+                    PgType::TIMESTAMPTZ, // TIMESTAMP
+                ];
+                let mut logs_buffer = Vec::with_capacity(100);
+                let mut path_buffer = Vec::<u8>::new();
+                let mut version_buffer = Vec::<u8>::new();
+                let mut user_agent_buffer = Vec::<u8>::new();
+
+                'recv: while rx.recv_many(&mut logs_buffer, 100).await > 0 {
+                    let connection = match pool.get().await {
+                        Ok(conn) => conn,
+                        Err(e) => {
+                            log::error!("Unable to acquire postgresql connection: {e}");
+                            continue 'recv;
+                        }
+                    };
+                    let copy_sink_res = connection
+                        .copy_in::<_, bytes::Bytes>(
+                            "COPY faucet_http_events FROM STDIN WITH (FORMAT binary)",
+                        )
+                        .await;
+
+                    match copy_sink_res {
+                        Ok(copy_sink) => {
+                            let mut copy_in_writer =
+                                tokio_postgres::binary_copy::BinaryCopyInWriter::new(
+                                    copy_sink, types,
+                                );
+
+                            let mut copy_in_writer = pin!(copy_in_writer);
+
+                            log::debug!(
+                                "Writing {} http events to the database",
+                                logs_buffer.len()
+                            );
+
+                            'write: for (timespamp, log_data) in logs_buffer.drain(..) {
+                                let target = &log_data.target;
+                                let ip = &log_data.ip;
+                                let method = &log_data.method.as_str();
+                                let _ = write!(path_buffer, "{}", log_data.path);
+                                let path = &std::str::from_utf8(&path_buffer).unwrap_or_default();
+                                let _ = write!(version_buffer, "{:?}", log_data.version);
+                                let version =
+                                    &std::str::from_utf8(&version_buffer).unwrap_or_default();
+                                let status = &log_data.status;
+                                let user_agent = match &log_data.user_agent {
+                                    LogOption::Some(v) => v.to_str().ok(),
+                                    LogOption::None => None,
+                                };
+
+                                let elapsed = &log_data.elapsed;
+                                let copy_result = copy_in_writer
+                                    .as_mut()
+                                    .write(&[
+                                        &namespace,
+                                        target,
+                                        ip,
+                                        method,
+                                        path,
+                                        version,
+                                        status,
+                                        &user_agent,
+                                        elapsed,
+                                        &timespamp,
+                                    ])
+                                    .await;
+
+                                path_buffer.clear();
+                                version_buffer.clear();
+                                user_agent_buffer.clear();
+
+                                if let Err(e) = copy_result {
+                                    log::error!("Error writing to PostgreSQL: {e}");
+                                    break 'write;
+                                }
+                            }
+
+                            let copy_in_finish_res = copy_in_writer.finish().await;
+                            if let Err(e) = copy_in_finish_res {
+                                log::error!("Error writing to PostgreSQL: {e}");
+                                continue 'recv;
+                            }
+                        }
+                        Err(e) => {
+                            log::error!(target: "telemetry", "Error writing to the database: {e}")
+                        }
+                    }
+                }
+            })
+        };
+
+        Ok(TelemetryManager {
+            _pool: pool,
+            join_handle,
+            sender: TelemetrySender { sender: tx },
+        })
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -12,20 +12,20 @@ use crate::{
 
 #[derive(Clone)]
 pub struct TelemetrySender {
-    pub sender: UnboundedSender<(chrono::DateTime<Local>, LogData)>,
+    pub sender_http_events: UnboundedSender<(chrono::DateTime<Local>, LogData)>,
 }
 
 impl TelemetrySender {
-    pub fn send(&self, data: LogData) {
+    pub fn send_http_event(&self, data: LogData) {
         let timestamp = chrono::Local::now();
-        let _ = self.sender.send((timestamp, data));
+        let _ = self.sender_http_events.send((timestamp, data));
     }
 }
 
 pub struct TelemetryManager {
     _pool: deadpool_postgres::Pool,
     pub sender: TelemetrySender,
-    pub join_handle: JoinHandle<()>,
+    pub http_events_join_handle: JoinHandle<()>,
 }
 
 fn make_tls() -> tokio_postgres_rustls::MakeRustlsConnect {
@@ -40,147 +40,155 @@ type PgType = tokio_postgres::types::Type;
 
 impl TelemetryManager {
     pub fn start(
-        namespace: impl AsRef<str>,
-        database_url: impl AsRef<str>,
+        namespace: &str,
+        version: Option<&str>,
+        database_url: &str,
     ) -> FaucetResult<TelemetryManager> {
-        let namespace = Box::<str>::from(namespace.as_ref());
-        let config = tokio_postgres::Config::from_str(database_url.as_ref())?;
+        let config = tokio_postgres::Config::from_str(database_url)?;
         let mgr_config = ManagerConfig {
             recycling_method: RecyclingMethod::Fast,
         };
         let mgr = Manager::from_config(config, make_tls(), mgr_config);
         let pool = Pool::builder(mgr).max_size(10).build()?;
 
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(_, LogData)>();
-
-        let join_handle = {
-            let pool = pool.clone();
-            tokio::task::spawn(async move {
-                let types = &[
-                    PgType::UUID,        // UUID
-                    PgType::TEXT,        // Namespace
-                    PgType::TEXT,        // Target
-                    PgType::TEXT,        // Worker Route
-                    PgType::INT4,        // Worker ID
-                    PgType::INET,        // IpAddr
-                    PgType::TEXT,        // Method
-                    PgType::TEXT,        // Path
-                    PgType::TEXT,        // Query Params
-                    PgType::TEXT,        // Version
-                    PgType::INT2,        // Status
-                    PgType::TEXT,        // User Agent
-                    PgType::INT8,        // Elapsed
-                    PgType::TIMESTAMPTZ, // TIMESTAMP
-                ];
-                let mut logs_buffer = Vec::with_capacity(100);
-                let mut path_buffer = Vec::<u8>::new();
-                let mut query_buffer = Vec::<u8>::new();
-                let mut version_buffer = Vec::<u8>::new();
-                let mut user_agent_buffer = Vec::<u8>::new();
-
-                'recv: while rx.recv_many(&mut logs_buffer, 100).await > 0 {
-                    let connection = match pool.get().await {
-                        Ok(conn) => conn,
-                        Err(e) => {
-                            log::error!("Unable to acquire postgresql connection: {e}");
-                            continue 'recv;
-                        }
-                    };
-                    let copy_sink_res = connection
-                        .copy_in::<_, bytes::Bytes>(
-                            "COPY faucet_http_events FROM STDIN WITH (FORMAT binary)",
-                        )
-                        .await;
-
-                    match copy_sink_res {
-                        Ok(copy_sink) => {
-                            let mut copy_in_writer =
-                                tokio_postgres::binary_copy::BinaryCopyInWriter::new(
-                                    copy_sink, types,
-                                );
-
-                            let mut copy_in_writer = pin!(copy_in_writer);
-
-                            log::debug!(
-                                "Writing {} http events to the database",
-                                logs_buffer.len()
-                            );
-
-                            'write: for (timespamp, log_data) in logs_buffer.drain(..) {
-                                let uuid = &log_data.state_data.uuid;
-                                let target = &log_data.state_data.target;
-                                let worker_id = log_data.state_data.worker_id as i32;
-                                let worker_route = log_data.state_data.worker_route;
-                                let ip = &log_data.state_data.ip;
-                                let method = &log_data.method.as_str();
-                                let _ = write!(path_buffer, "{}", log_data.path.path());
-                                let path = &std::str::from_utf8(&path_buffer).unwrap_or_default();
-                                let _ = write!(
-                                    query_buffer,
-                                    "{}",
-                                    log_data.path.query().unwrap_or_default()
-                                );
-                                let query = &std::str::from_utf8(&query_buffer).unwrap_or_default();
-                                let query = if query.is_empty() { None } else { Some(query) };
-                                let _ = write!(version_buffer, "{:?}", log_data.version);
-                                let version =
-                                    &std::str::from_utf8(&version_buffer).unwrap_or_default();
-                                let status = &log_data.status;
-                                let user_agent = match &log_data.user_agent {
-                                    LogOption::Some(v) => v.to_str().ok(),
-                                    LogOption::None => None,
-                                };
-
-                                let elapsed = &log_data.elapsed;
-                                let copy_result = copy_in_writer
-                                    .as_mut()
-                                    .write(&[
-                                        uuid,
-                                        &namespace,
-                                        target,
-                                        &worker_route,
-                                        &worker_id,
-                                        ip,
-                                        method,
-                                        path,
-                                        &query,
-                                        version,
-                                        status,
-                                        &user_agent,
-                                        elapsed,
-                                        &timespamp,
-                                    ])
-                                    .await;
-
-                                path_buffer.clear();
-                                version_buffer.clear();
-                                user_agent_buffer.clear();
-                                query_buffer.clear();
-
-                                if let Err(e) = copy_result {
-                                    log::error!("Error writing to PostgreSQL: {e}");
-                                    break 'write;
-                                }
-                            }
-
-                            let copy_in_finish_res = copy_in_writer.finish().await;
-                            if let Err(e) = copy_in_finish_res {
-                                log::error!("Error writing to PostgreSQL: {e}");
-                                continue 'recv;
-                            }
-                        }
-                        Err(e) => {
-                            log::error!(target: "telemetry", "Error writing to the database: {e}")
-                        }
-                    }
-                }
-            })
-        };
+        let (sender_http_events, http_events_join_handle) =
+            handle_http_events(pool.clone(), namespace, version);
 
         Ok(TelemetryManager {
             _pool: pool,
-            join_handle,
-            sender: TelemetrySender { sender: tx },
+            http_events_join_handle,
+            sender: TelemetrySender { sender_http_events },
         })
     }
+}
+
+fn handle_http_events(
+    pool: Pool,
+    namespace: &str,
+    version: Option<&str>,
+) -> (
+    UnboundedSender<(chrono::DateTime<Local>, LogData)>,
+    JoinHandle<()>,
+) {
+    let namespace = Box::<str>::from(namespace);
+    let version = version.map(Box::<str>::from);
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(_, LogData)>();
+    let handle = tokio::task::spawn(async move {
+        let types = &[
+            PgType::UUID,        // UUID
+            PgType::TEXT,        // Namespace
+            PgType::TEXT,        // Version
+            PgType::TEXT,        // Target
+            PgType::TEXT,        // Worker Route
+            PgType::INT4,        // Worker ID
+            PgType::INET,        // IpAddr
+            PgType::TEXT,        // Method
+            PgType::TEXT,        // Path
+            PgType::TEXT,        // Query Params
+            PgType::TEXT,        // HTTP Version
+            PgType::INT2,        // Status
+            PgType::TEXT,        // User Agent
+            PgType::INT8,        // Elapsed
+            PgType::TIMESTAMPTZ, // TIMESTAMP
+        ];
+        let mut logs_buffer = Vec::with_capacity(100);
+        let mut path_buffer = Vec::<u8>::new();
+        let mut query_buffer = Vec::<u8>::new();
+        let mut version_buffer = Vec::<u8>::new();
+        let mut user_agent_buffer = Vec::<u8>::new();
+
+        'recv: while rx.recv_many(&mut logs_buffer, 100).await > 0 {
+            let connection = match pool.get().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    log::error!("Unable to acquire postgresql connection: {e}");
+                    continue 'recv;
+                }
+            };
+            let copy_sink_res = connection
+                .copy_in::<_, bytes::Bytes>(
+                    "COPY faucet_http_events FROM STDIN WITH (FORMAT binary)",
+                )
+                .await;
+
+            match copy_sink_res {
+                Ok(copy_sink) => {
+                    let mut copy_in_writer =
+                        tokio_postgres::binary_copy::BinaryCopyInWriter::new(copy_sink, types);
+
+                    let mut copy_in_writer = pin!(copy_in_writer);
+
+                    log::debug!("Writing {} http events to the database", logs_buffer.len());
+
+                    'write: for (timestamp, log_data) in logs_buffer.drain(..) {
+                        let uuid = &log_data.state_data.uuid;
+                        let target = &log_data.state_data.target;
+                        let worker_id = log_data.state_data.worker_id as i32;
+                        let worker_route = log_data.state_data.worker_route;
+                        let ip = &log_data.state_data.ip;
+                        let method = &log_data.method.as_str();
+                        let _ = write!(path_buffer, "{}", log_data.path.path());
+                        let path = &std::str::from_utf8(&path_buffer).unwrap_or_default();
+                        let _ = write!(
+                            query_buffer,
+                            "{}",
+                            log_data.path.query().unwrap_or_default()
+                        );
+                        let query = &std::str::from_utf8(&query_buffer).unwrap_or_default();
+                        let query = if query.is_empty() { None } else { Some(query) };
+                        let _ = write!(version_buffer, "{:?}", log_data.version);
+                        let http_version =
+                            &std::str::from_utf8(&version_buffer).unwrap_or_default();
+                        let status = &log_data.status;
+                        let user_agent = match &log_data.user_agent {
+                            LogOption::Some(v) => v.to_str().ok(),
+                            LogOption::None => None,
+                        };
+
+                        let elapsed = &log_data.elapsed;
+                        let copy_result = copy_in_writer
+                            .as_mut()
+                            .write(&[
+                                uuid,
+                                &namespace,
+                                &version,
+                                target,
+                                &worker_route,
+                                &worker_id,
+                                ip,
+                                method,
+                                path,
+                                &query,
+                                http_version,
+                                status,
+                                &user_agent,
+                                elapsed,
+                                &timestamp,
+                            ])
+                            .await;
+
+                        path_buffer.clear();
+                        version_buffer.clear();
+                        user_agent_buffer.clear();
+                        query_buffer.clear();
+
+                        if let Err(e) = copy_result {
+                            log::error!("Error writing to PostgreSQL: {e}");
+                            break 'write;
+                        }
+                    }
+
+                    let copy_in_finish_res = copy_in_writer.finish().await;
+                    if let Err(e) = copy_in_finish_res {
+                        log::error!("Error writing to PostgreSQL: {e}");
+                        continue 'recv;
+                    }
+                }
+                Err(e) => {
+                    log::error!(target: "telemetry", "Error writing to the database: {e}")
+                }
+            }
+        }
+    });
+    (tx, handle)
 }


### PR DESCRIPTION
This feature will allow us track the number of requests, response times and other data for plumber APIs and Shiny Applications.

- Closes #151 

# The new feature

## HTTP Telemetry

faucet now offers the option of saving HTTP events to a PostgreSQL database.
This can be very helpful for tracking latency, total API calls and other
important information.

In order to use this feature you will need a PostgreSQL database with a table
called `faucet_http_events`. You can create the table using this table with
the following SQL query:

```sql
CREATE TABLE faucet_http_events (
    request_uuid UUID,
    namespace TEXT,
    version TEXT,
    target TEXT,
    worker_route TEXT,
    worker_id INT,
    ip_addr INET,
    method TEXT,
    path TEXT,
    query_params TEXT,
    http_version TEXT,
    status SMALLINT,
    user_agent TEXT,
    elapsed BIGINT,
    time TIMESTAMPTZ
);
```

### Connection Strings

In order to connect to the database you will need to pass the
`FAUCET_TELEMETRY_POSTGRES_STRING` environment variable or the
`--pg-con-string` CLI argument.

This should include either a connection string or a URL with the `postgres://`
protocol.

#### Example connection strings

```sh
FAUCET_TELEMETRY_POSTGRES_STRING="host=localhost user=postgres connect_timeout=10 keepalives=0"
FAUCET_TELEMETRY_POSTGRES_STRING="host=/var/lib/postgresql,localhost port=1234 user=postgres password='password with spaces'"
FAUCET_TELEMETRY_POSTGRES_STRING="postgresql://user@localhost"
FAUCET_TELEMETRY_POSTGRES_STRING="postgresql://user:password@127.0.0.1/mydb?connect_timeout=10"
```

### Telemetry Namespaces

It is likely you want to track different services on the same database. You
can control the column `namespace` using the environment variable
`FAUCET_TELEMETRY_NAMESPACE` or cli argument `--telemetry-namespace`. By
default, this value is `"faucet"`