### PR TITLE
fix: Fixes bug with double reconnection

### DIFF
--- a/src/server/reconnect.js
+++ b/src/server/reconnect.js
@@ -53,7 +53,7 @@ class ReconnectingWebSocket {
     this._maxReconnectAttempts =
       options.maxReconnectAttempts != null ? options.maxReconnectAttempts : 50;
     this._reconnectDelay =
-      options.reconnectDelay != null ? options.reconnectDelay : 100; // 100ms
+      options.reconnectDelay != null ? options.reconnectDelay : 500; // 100ms
 
     // Initial connection
     this.connect();


### PR DESCRIPTION
* Closes #223 

The error was that the task that purged the connection waited on a lock. Now it does not.