### PR TITLE
Docs: Update FAQs for Address/Port already in use issue

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -8,3 +8,17 @@ and how to read the end-user's IP address.
 
 We can fix this by setting the `FAUCET_IP_FROM` environment variable or
 `--ip-from` CLI argument to `x-forwarded-for`.
+
+### I'm getting "address already in use" errors with my workers.
+
+If you see errors like `createTcpServer: address already in use` or `Failed to create server`, this typically means that your application code has hardcoded port settings that conflict with faucet's port management.
+
+Faucet automatically assigns unique ports to each worker, but your application code might be overriding these with explicit port declarations.
+
+**Common causes and solutions:**
+
+- **Shiny apps:** Check for `options(shiny.port = ...)` calls in your code and remove them. Also avoid hardcoded ports in `shiny::runApp(port = ...)` calls.
+- **Plumber APIs:** Remove explicit port settings in `plumber::pr_run(port = ...)` calls.
+- **Other services:** Ensure no hardcoded ports are set in configuration files or startup scripts.
+
+Let faucet manage the port assignments automatically for proper load balancing to work.

--- a/docs/es/faq.md
+++ b/docs/es/faq.md
@@ -1,0 +1,24 @@
+# Preguntas Frecuentes
+
+### faucet no está balanceando la carga de mi aplicación Shiny en Google Cloud Run.
+
+Google Cloud Run tiene un proxy entre las solicitudes enviadas y los
+servicios subyacentes reales. Por lo tanto, necesitamos decirle a faucet
+quién se está conectando y cómo leer la dirección IP del usuario final.
+
+Podemos solucionarlo configurando la variable de entorno `FAUCET_IP_FROM` o
+el argumento CLI `--ip-from` a `x-forwarded-for`.
+
+### Estoy obteniendo errores de "address already in use" con mis workers.
+
+Si ves errores como `createTcpServer: address already in use` o `Failed to create server`, esto típicamente significa que el código de tu aplicación tiene configuraciones de puerto codificadas que entran en conflicto con la gestión de puertos de faucet.
+
+Faucet asigna automáticamente puertos únicos a cada worker, pero el código de tu aplicación podría estar sobrescribiendo estos con declaraciones explícitas de puerto.
+
+**Causas comunes y soluciones:**
+
+- **Aplicaciones Shiny:** Verifica llamadas a `options(shiny.port = ...)` en tu código y elimínalas. También evita puertos codificados en llamadas a `shiny::runApp(port = ...)`.
+- **APIs Plumber:** Elimina configuraciones explícitas de puerto en llamadas a `plumber::pr_run(port = ...)`.
+- **Otros servicios:** Asegúrate de que no haya puertos codificados en archivos de configuración o scripts de inicio.
+
+Deja que faucet gestione las asignaciones de puerto automáticamente para que el balanceo de carga funcione correctamente.


### PR DESCRIPTION
Closes #50 

I faced this issue and figured I will update the documentation myself.

- Add an FAQ entry for the address already in use issue with hint on the usual suspects
- Add an `faq.md` file for `es` — it did not already exist. Note that this is machine translated and may not be accurate and need proofreading.
